### PR TITLE
Use fixed Flask version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mod_wsgi
-Flask
-flask-restful
+Flask==1.1.2
+flask-restful==0.3.8
 pymongo
+


### PR DESCRIPTION
Due a change in latest Flask apparently, the flask-restful dep is not resolved. Downgrading to Flask 1.1.2 seems to solve the issue. 

```
ImportError: cannot import name '_endpoint_from_view_func' from 'flask.helpers' (/opt/app-root/lib64/python3.8/site-packages/flask/helpers.py)
```

Similar issue: https://github.com/P0cL4bs/wifipumpkin3/issues/117
