### PR TITLE
Feature/el listener port fix

### DIFF
--- a/pipelines/nationalparks-triggers-all.yaml
+++ b/pipelines/nationalparks-triggers-all.yaml
@@ -68,7 +68,7 @@ metadata:
   name: el-nationalparks
 spec:
   port:
-    targetPort: 8080
+    targetPort: http-listener
   to:
     kind: Service
     name: el-nationalparks

--- a/wsgi.py
+++ b/wsgi.py
@@ -85,7 +85,7 @@ class DataLoad(Resource):
             if entries:
                 collection.insert_many(entries)
 
-        return 'Items inserted in database: %s' % collection.count()
+        return 'Items inserted in database: %s' % collection.estimated_document_count()
 
 api.add_resource(DataLoad, '/ws/data/load')
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -64,7 +64,7 @@ class DataLoad(Resource):
         database = client[DB_NAME]
         collection = database.nationalparks
 
-        collection.remove({})
+        collection.delete_many({})
         collection.create_index([('Location', GEO2D)])
 
         with open(DATASET_FILE, 'r') as fp:


### PR DESCRIPTION
Updated use of collection object, changed remove to delete_many and count to estimated_document_count() as the users got errors lately when using the python module. 
Also updated port in the el-nationalparks trigger as the webhook didnt work before.