### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mod_wsgi
 Flask==1.1.2
 flask-restful==0.3.8
-pymongo
+pymongo<4.0
 


### PR DESCRIPTION
Recently, PyMongo 4.0 was released, which removes the Collection.remove() method. This method is called in wsgi.py, and breaks loading of data. I'm not a Mongo expert, and I haven't looked at what replaces the remove() method, but a simple fix is to pin PyMongo at <4.0. This forces installation of 3.12.3 (as I write this) and makes data loading work again.